### PR TITLE
Itertools' `find_or_{first,last}` methods

### DIFF
--- a/src/iter1.rs
+++ b/src/iter1.rs
@@ -811,20 +811,20 @@ where
         unsafe { self.and_then_unchecked(move |items| items.unique_by(f)) }
     }
 
-    pub fn find_or_first<P>(self, predicate: P) -> I::Item
+    pub fn find_or_first<F>(self, f: F) -> I::Item
     where
-        P: FnMut(&I::Item) -> bool,
+        F: FnMut(&I::Item) -> bool,
     {
-        let item = self.items.find_or_first(predicate);
+        let item = self.items.find_or_first(f);
         // SAFETY: `self` must be non-empty.
         unsafe { item.unwrap_maybe_unchecked() }
     }
 
-    pub fn find_or_last<P>(self, predicate: P) -> I::Item
+    pub fn find_or_last<F>(self, f: F) -> I::Item
     where
-        P: FnMut(&I::Item) -> bool,
+        F: FnMut(&I::Item) -> bool,
     {
-        let item = self.items.find_or_last(predicate);
+        let item = self.items.find_or_last(f);
         // SAFETY: `self` must be non-empty.
         unsafe { item.unwrap_maybe_unchecked() }
     }

--- a/src/iter1.rs
+++ b/src/iter1.rs
@@ -810,6 +810,22 @@ where
         // SAFETY: This combinator function cannot reduce the cardinality of the iterator to zero.
         unsafe { self.and_then_unchecked(move |items| items.unique_by(f)) }
     }
+
+    pub fn find_or_first<P>(self, predicate: P) -> I::Item
+    where
+        P: FnMut(&I::Item) -> bool,
+    {
+        // SAFETY: `self` must be non-empty.
+        unsafe { self.items.find_or_first(predicate).unwrap_maybe_unchecked() }
+    }
+
+    pub fn find_or_last<P>(self, predicate: P) -> I::Item
+    where
+        P: FnMut(&I::Item) -> bool,
+    {
+        // SAFETY: `self` must be non-empty.
+        unsafe { self.items.find_or_last(predicate).unwrap_maybe_unchecked() }
+    }
 }
 
 #[cfg(feature = "rayon")]

--- a/src/iter1.rs
+++ b/src/iter1.rs
@@ -815,16 +815,18 @@ where
     where
         P: FnMut(&I::Item) -> bool,
     {
+        let item = self.items.find_or_first(predicate);
         // SAFETY: `self` must be non-empty.
-        unsafe { self.items.find_or_first(predicate).unwrap_maybe_unchecked() }
+        unsafe { item.unwrap_maybe_unchecked() }
     }
 
     pub fn find_or_last<P>(self, predicate: P) -> I::Item
     where
         P: FnMut(&I::Item) -> bool,
     {
+        let item = self.items.find_or_last(predicate);
         // SAFETY: `self` must be non-empty.
-        unsafe { self.items.find_or_last(predicate).unwrap_maybe_unchecked() }
+        unsafe { item.unwrap_maybe_unchecked() }
     }
 }
 


### PR DESCRIPTION
Not quite sure why `OptionExt` exists but I've used it nonetheless.