### PR TITLE
Remove unnecessary type bound on `Iterator1::zip`

### DIFF
--- a/src/iter1.rs
+++ b/src/iter1.rs
@@ -680,7 +680,7 @@ where
 
     pub fn zip<T>(self, zipped: T) -> Iterator1<Zip<I, T::IntoIter>>
     where
-        T: IntoIterator1<Item = I::Item>,
+        T: IntoIterator1,
     {
         // SAFETY: Both input iterators are non-empty, and so this combinator function cannot
         //         reduce the cardinality to zero.


### PR DESCRIPTION
Zip returns tuples, so I assume this bound was there by accident.