### PR TITLE
Implement `rkyv` and `facet` support for `NonEmpty`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,9 @@ rustdoc-args = [
 [features]
 default = ["std"]
 alloc = [
+    "facet?/alloc",
     "itertools?/use_alloc",
+    "rkyv?/alloc",
     "serde?/alloc",
 ]
 arbitrary = [
@@ -42,13 +44,17 @@ arbitrary = [
 ]
 arrayvec = [
     "dep:arrayvec",
+    "rkyv?/arrayvec-0_7",
     "schemars?/arrayvec07",
 ]
 either = ["dep:either"]
+facet = ["dep:facet", "alloc"]
 heapless = ["dep:heapless"]
 indexmap = [
     "dep:indexmap",
     "alloc",
+    "facet?/indexmap",
+    "rkyv?/indexmap-2",
     "schemars?/indexmap2",
 ]
 itertools = [
@@ -65,6 +71,7 @@ schemars = [
     "dep:serde_json",
     "alloc",
 ]
+rkyv = ["dep:rkyv"]
 serde = [
     "dep:serde",
     "arrayvec?/serde",
@@ -75,13 +82,16 @@ serde = [
 smallvec = [
     "dep:smallvec",
     "alloc",
+    "rkyv?/smallvec-1",
     "schemars?/smallvec1",
 ]
 std = [
     "alloc",
     "either?/std",
+    "facet?/std",
     "indexmap?/std",
     "itertools?/use_std",
+    "rkyv?/std",
     "schemars?/std",
     "serde?/std",
     "smallvec?/write",
@@ -96,6 +106,11 @@ optional = true
 
 [dependencies.arrayvec]
 version = "^0.7.0"
+default-features = false
+optional = true
+
+[dependencies.facet]
+version = "^0.43.0"
 default-features = false
 optional = true
 
@@ -116,6 +131,11 @@ optional = true
 
 [dependencies.itertools]
 version = "^0.14.0"
+default-features = false
+optional = true
+
+[dependencies.rkyv]
+version = "^0.8.0"
 default-features = false
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ assert_eq!(xs.as_slice(), &[0]);
 
 Non-empty collection APIs that exhibit different behavior from their
 counterparts are distinct in Mitsein. For example, functions that take items out
-of collections like `Vec1::pop_if_many` have an `_if_many` suffix and  return a
+of collections like `Vec1::pop_if_many` have an `_if_many` suffix and return a
 proxy type rather than an `Option`. This leads to more explicit and distinct
 expressions like `xs.pop_if_many()`, `xs.pop_if_many().or_get_only()`, and
 `xs.remove_if_many(1).or_else_replace_only(|| 0)`.
@@ -218,7 +218,7 @@ invariants instead.
 
 Checking is toggled in the `safety` module. The presence of items in non-empty
 types is asserted in tests builds, but not in non-test builds (nor in the
-context of [Miri][`miri`]). APIs that interact with these  conditional checks
+context of [Miri][`miri`]). APIs that interact with these conditional checks
 use the nomenclature "maybe unchecked", such as `unwrap_maybe_unchecked`.
 
 ## Integrations and Feature Flags
@@ -227,15 +227,17 @@ Mitsein provides some optional features and integrations via the following
 feature flags.
 
 | Feature     | Also Enables | Default | Crate         | Description                                                    |
-|-------------|--------------|---------|---------------|----------------------------------------------------------------|
+| ----------- | ------------ | ------- | ------------- | -------------------------------------------------------------- |
 | `alloc`     |              | No      | `alloc`       | Non-empty collections that allocate, like `Vec1`.              |
 | `arbitrary` | `std`        | No      | [`arbitrary`] | Construction of arbitrary non-empty collections.               |
 | `arrayvec`  |              | No      | [`arrayvec`]  | Non-empty implementations of [`arrayvec`] types.               |
 | `either`    |              | No      | [`either`]    | Non-empty iterator implementation for `Either`.                |
+| `facet`     | `alloc`      | No      | [`facet`]     | Compile-time reflection for non-empty types.                   |
 | `heapless`  |              | No      | [`heapless`]  | Non-empty implementations of [`heapless`] types.               |
 | `indexmap`  | `alloc`      | No      | [`indexmap`]  | Non-empty implementations of [`indexmap`] types.               |
 | `itertools` | `either`     | No      | [`itertools`] | Combinators from [`itertools`] for `Iterator1`.                |
 | `rayon`     | `std`        | No      | [`rayon`]     | Parallel operations for non-empty types.                       |
+| `rkyv`      |              | No      | [`rkyv`]      | Zero-copy de/serialization for non-empty types.                |
 | `schemars`  | `alloc`      | No      | [`schemars`]  | JSON schema generation for non-empty types.                    |
 | `serde`     |              | No      | [`serde`]     | De/serialization of non-empty collections with [`serde`].      |
 | `smallvec`  | `alloc`      | No      | [`smallvec`]  | Non-empty implementations of [`smallvec`] types.               |
@@ -244,6 +246,7 @@ feature flags.
 [`arbitrary`]: https://crates.io/crates/arbitrary
 [`arrayvec`]: https://crates.io/crates/arrayvec
 [`either`]: https://crates.io/crates/either
+[`facet`]: https://crates.io/crates/facet
 [`heapless`]: https://crates.io/crates/heapless
 [`indexmap`]: https://crates.io/crates/indexmap
 [`itertools`]: https://crates.io/crates/itertools
@@ -251,6 +254,7 @@ feature flags.
 [`nonempty`]: https://crates.io/crates/nonempty
 [`nunny`]: https://crates.io/crates/nunny
 [`rayon`]: https://crates.io/crates/rayon
+[`rkyv`]: https://crates.io/crates/rkyv
 [`schemars`]: https://crates.io/crates/schemars
 [`serde`]: https://crates.io/crates/serde
 [`smallvec`]: https://crates.io/crates/smallvec

--- a/src/facet.rs
+++ b/src/facet.rs
@@ -1,0 +1,49 @@
+#![cfg(feature = "facet")]
+#![cfg_attr(docsrs, doc(cfg(feature = "facet")))]
+
+use facet::Facet;
+
+use crate::NonEmpty;
+
+// SAFETY: `NonEmpty<T>` is `#[repr(transparent)]` over `T`. The shape correctly describes it as a
+// transparent struct with a single field at offset 0, pointing to `T`'s shape.
+unsafe impl<'facet, T> Facet<'facet> for NonEmpty<T>
+where
+    T: Facet<'facet> + 'facet,
+{
+    const SHAPE: &'static facet::Shape = &const {
+        facet::ShapeBuilder::for_sized::<NonEmpty<T>>("NonEmpty")
+            .ty(facet::Type::User(facet::UserType::Struct(
+                facet::StructType {
+                    repr: facet::Repr::transparent(),
+                    kind: facet::StructKind::Struct,
+                    fields: &const {
+                        [facet::FieldBuilder::new("items", facet::shape_of::<T>, 0).build()]
+                    },
+                },
+            )))
+            .inner(<T as Facet>::SHAPE)
+            .build()
+    };
+}
+
+#[cfg(all(test, feature = "alloc"))]
+mod tests {
+    use alloc::vec::Vec;
+    use facet::Facet;
+
+    use crate::{EmptyError, NonEmpty};
+
+    #[test]
+    fn non_empty_vec_has_shape() {
+        let shape = <NonEmpty<Vec<u8>> as Facet>::SHAPE;
+        assert_eq!(shape.type_identifier, "NonEmpty");
+        assert!(shape.inner.is_some());
+    }
+
+    #[test]
+    fn empty_error_has_shape() {
+        let shape = <EmptyError<u32> as Facet>::SHAPE;
+        assert_eq!(shape.type_identifier, "EmptyError");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,10 +221,12 @@
 //! | `arbitrary` | `std`        | No      | [`arbitrary`] | Construction of arbitrary non-empty collections.               |
 //! | `arrayvec`  |              | No      | [`arrayvec`]  | Non-empty implementations of [`arrayvec`] types.               |
 //! | `either`    |              | No      | [`either`]    | Non-empty iterator implementation for `Either`.                |
+//! | `facet`     | `alloc`      | No      | [`facet`]     | Compile-time reflection for non-empty types.                   |
 //! | `heapless`  |              | No      | [`heapless`]  | Non-empty implementations of [`heapless`] types.               |
 //! | `indexmap`  | `alloc`      | No      | [`indexmap`]  | Non-empty implementations of [`indexmap`] types.               |
 //! | `itertools` | `either`     | No      | [`itertools`] | Combinators from [`itertools`] for `Iterator1`.                |
 //! | `rayon`     | `std`        | No      | [`rayon`]     | Parallel operations for non-empty types.                       |
+//! | `rkyv`      |              | No      | [`rkyv`]      | Zero-copy de/serialization for non-empty types.                |
 //! | `schemars`  | `alloc`      | No      | [`schemars`]  | JSON schema generation for non-empty types.                    |
 //! | `serde`     |              | No      | [`serde`]     | De/serialization of non-empty collections with [`serde`].      |
 //! | `smallvec`  | `alloc`      | No      | [`smallvec`]  | Non-empty implementations of [`smallvec`] types.               |
@@ -241,6 +243,7 @@
 //! [`CowSlice1Ext`]: crate::borrow1::CowSlice1Ext
 //! [`CowStr1Ext`]: crate::borrow1::CowStr1Ext
 //! [`either`]: https://crates.io/crates/either
+//! [`facet`]: https://crates.io/crates/facet
 //! [`Except`]: crate::except
 //! [`heapless`]: https://crates.io/crates/heapless
 //! [`indexmap`]: https://crates.io/crates/indexmap
@@ -249,6 +252,7 @@
 //! [`itertools`]: https://crates.io/crates/itertools
 //! [`ParallelIterator1`]: crate::iter1::ParallelIterator1
 //! [`rayon`]: https://crates.io/crates/rayon
+//! [`rkyv`]: https://crates.io/crates/rkyv
 //! [`RcSlice1Ext`]: crate::rc1::RcSlice1Ext
 //! [`RcStr1Ext`]: crate::rc1::RcStr1Ext
 //! [`schemars`]: https://crates.io/crates/schemars
@@ -320,6 +324,8 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+mod facet;
+mod rkyv;
 mod safety;
 mod schemars;
 mod serde;
@@ -533,6 +539,11 @@ where
 
 /// An error in which a non-empty value is expected but an empty value is observed.
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(::rkyv::Archive, ::rkyv::Serialize, ::rkyv::Deserialize)
+)]
+#[cfg_attr(feature = "facet", derive(::facet::Facet))]
 pub struct EmptyError<T> {
     items: T,
 }
@@ -763,6 +774,10 @@ where
 /// [`BTreeMap1`]: crate::btree_map1::BTreeMap1
 /// [`OccupiedEntry`]: crate::btree_map1::OccupiedEntry
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(::rkyv::Archive, ::rkyv::Serialize, ::rkyv::Deserialize)
+)]
 pub enum Cardinality<O, M> {
     /// Exactly one item.
     One(O),

--- a/src/rkyv.rs
+++ b/src/rkyv.rs
@@ -1,0 +1,77 @@
+#![cfg(feature = "rkyv")]
+#![cfg_attr(docsrs, doc(cfg(feature = "rkyv")))]
+
+use rkyv::rancor::Fallible;
+use rkyv::{Archive, Deserialize, Place, Portable, Serialize};
+
+use crate::NonEmpty;
+
+// SAFETY: `NonEmpty<T>` is `#[repr(transparent)]` over `T`, so it has identical layout.
+// `Portable` when `T` is `Portable`.
+unsafe impl<T: Portable> Portable for NonEmpty<T> {}
+
+impl<T: Archive> Archive for NonEmpty<T> {
+    type Archived = NonEmpty<T::Archived>;
+    type Resolver = T::Resolver;
+
+    fn resolve(&self, resolver: Self::Resolver, out: Place<Self::Archived>) {
+        // SAFETY: `NonEmpty<T::Archived>` is `#[repr(transparent)]` over `T::Archived`, so the
+        // place can be safely cast.
+        let out_inner = unsafe { out.cast_unchecked::<T::Archived>() };
+        self.items.resolve(resolver, out_inner);
+    }
+}
+
+impl<T, S> Serialize<S> for NonEmpty<T>
+where
+    T: Serialize<S>,
+    S: Fallible + ?Sized,
+{
+    fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        self.items.serialize(serializer)
+    }
+}
+
+impl<T, D> Deserialize<NonEmpty<T>, D> for NonEmpty<T::Archived>
+where
+    T: Archive,
+    T::Archived: Deserialize<T, D>,
+    D: Fallible + ?Sized,
+{
+    fn deserialize(&self, deserializer: &mut D) -> Result<NonEmpty<T>, D::Error> {
+        self.items
+            .deserialize(deserializer)
+            .map(|items| NonEmpty { items })
+    }
+}
+
+#[cfg(all(test, feature = "alloc"))]
+mod tests {
+    use rkyv::rancor;
+
+    use crate::vec1::Vec1;
+
+    #[test]
+    fn roundtrip_vec1() {
+        let original = Vec1::from_head_and_tail(1u8, [2, 3, 4]);
+        let bytes = rkyv::to_bytes::<rancor::Error>(&original).unwrap();
+        let archived = unsafe { rkyv::access_unchecked::<rkyv::Archived<Vec1<u8>>>(&bytes) };
+        assert_eq!(archived.items.len(), 4);
+        assert_eq!(archived.items[0], 1);
+        assert_eq!(archived.items[3], 4);
+    }
+
+    #[test]
+    fn roundtrip_cardinality() {
+        use crate::{ArchivedCardinality, Cardinality};
+
+        let original = Cardinality::<u32, u32>::Many(42);
+        let bytes = rkyv::to_bytes::<rancor::Error>(&original).unwrap();
+        let archived =
+            unsafe { rkyv::access_unchecked::<rkyv::Archived<Cardinality<u32, u32>>>(&bytes) };
+        match archived {
+            ArchivedCardinality::Many(v) => assert_eq!(*v, 42),
+            _ => panic!("expected Many variant"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `rkyv` (zero-copy serialization) and `facet` (compile-time reflection) behind optional feature flags
- Manual `Archive`, `Serialize`, `Deserialize`, and `Portable` impls for `NonEmpty<T>` using the `#[repr(transparent)]` layout via `Place::cast_unchecked`
- Manual `Facet` impl for `NonEmpty<T>` marking it as a transparent wrapper with `inner` pointing to `T`'s shape
- Derive macros for `EmptyError` (`rkyv` + `facet`) and `Cardinality` (`rkyv`)
- Feature forwarding for `alloc`, `std`, `arrayvec`, `indexmap`, `smallvec`

## Test plan

- [x] `cargo check --features rkyv` / `--features facet` / `--features rkyv,facet`
- [x] `cargo check --all-features`
- [x] `cargo check --no-default-features --features rkyv`
- [x] `cargo check --no-default-features --features facet`
- [x] `cargo test --features rkyv,std` (roundtrip `Vec1`, `Cardinality`)
- [x] `cargo test --features facet,std` (`NonEmpty<Vec<u8>>` shape, `EmptyError` shape)
- [x] `cargo test --all-features` — 395 tests pass