### PR TITLE
Implement `slice1::split_last{,_mut}`

### DIFF
--- a/src/slice1.rs
+++ b/src/slice1.rs
@@ -150,6 +150,16 @@ impl<T> Slice1<T> {
         unsafe { safety::unwrap_option_maybe_unchecked(self.items.split_first_mut()) }
     }
 
+    pub const fn split_last(&self) -> (&T, &[T]) {
+        // SAFETY: `self` is non-empty.
+        unsafe { safety::unwrap_option_maybe_unchecked(self.items.split_last()) }
+    }
+
+    pub const fn split_last_mut(&mut self) -> (&mut T, &mut [T]) {
+        // SAFETY: `self` is non-empty.
+        unsafe { safety::unwrap_option_maybe_unchecked(self.items.split_last_mut()) }
+    }
+
     pub const fn first(&self) -> &T {
         // SAFETY: `self` is non-empty.
         unsafe { safety::unwrap_option_maybe_unchecked(self.items.first()) }


### PR DESCRIPTION
I personally would prefer keeping the order from the slice, so returning `(&[T], &T)`, but that would be inconsistent with [`slice::split_last`](https://doc.rust-lang.org/std/primitive.slice.html#method.split_last). If you do want that order just let me know.

The methods on slice were added way back in Rust 1.5 and I don't see any discussion about the order in either the [RFC](https://github.com/lilyball/rfcs/blob/a0d4344372279b2ff1f5f025aa65338758613ad1/text/0000-slice-tail-redesign.md) or the [tracking issue](https://github.com/rust-lang/rust/issues/27742). More recently added methods like [`split_last_chunk`](https://doc.rust-lang.org/std/primitive.slice.html#method.split_last_chunk) do have the pieces ordered as in the slice (although in this case the types are easier to interchange, whereas it's hard to use a `&T` for a `&[T]` or vice versa).