### PR TITLE
Implement `facet` support for `NonEmpty`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ rustdoc-args = [
 [features]
 default = ["std"]
 alloc = [
+    "facet?/alloc",
     "itertools?/use_alloc",
     "serde?/alloc",
 ]
@@ -45,10 +46,12 @@ arrayvec = [
     "schemars?/arrayvec07",
 ]
 either = ["dep:either"]
+facet = ["dep:facet", "alloc"]
 heapless = ["dep:heapless"]
 indexmap = [
     "dep:indexmap",
     "alloc",
+    "facet?/indexmap",
     "schemars?/indexmap2",
 ]
 itertools = [
@@ -80,6 +83,7 @@ smallvec = [
 std = [
     "alloc",
     "either?/std",
+    "facet?/std",
     "indexmap?/std",
     "itertools?/use_std",
     "schemars?/std",
@@ -101,6 +105,11 @@ optional = true
 
 [dependencies.either]
 version = "^1.15.0"
+default-features = false
+optional = true
+
+[dependencies.facet]
+version = "^0.43.0"
 default-features = false
 optional = true
 

--- a/src/facet.rs
+++ b/src/facet.rs
@@ -1,0 +1,49 @@
+#![cfg(feature = "facet")]
+#![cfg_attr(docsrs, doc(cfg(feature = "facet")))]
+
+use facet::Facet;
+
+use crate::NonEmpty;
+
+// SAFETY: `NonEmpty<T>` is `#[repr(transparent)]` over `T`. The shape correctly describes it as a
+// transparent struct with a single field at offset 0, pointing to `T`'s shape.
+unsafe impl<'facet, T> Facet<'facet> for NonEmpty<T>
+where
+    T: Facet<'facet> + 'facet,
+{
+    const SHAPE: &'static facet::Shape = &const {
+        facet::ShapeBuilder::for_sized::<NonEmpty<T>>("NonEmpty")
+            .ty(facet::Type::User(facet::UserType::Struct(
+                facet::StructType {
+                    repr: facet::Repr::transparent(),
+                    kind: facet::StructKind::Struct,
+                    fields: &const {
+                        [facet::FieldBuilder::new("items", facet::shape_of::<T>, 0).build()]
+                    },
+                },
+            )))
+            .inner(<T as Facet>::SHAPE)
+            .build()
+    };
+}
+
+#[cfg(all(test, feature = "alloc"))]
+mod tests {
+    use alloc::vec::Vec;
+    use facet::Facet;
+
+    use crate::{EmptyError, NonEmpty};
+
+    #[test]
+    fn non_empty_vec_has_shape() {
+        let shape = <NonEmpty<Vec<u8>> as Facet>::SHAPE;
+        assert_eq!(shape.type_identifier, "NonEmpty");
+        assert!(shape.inner.is_some());
+    }
+
+    #[test]
+    fn empty_error_has_shape() {
+        let shape = <EmptyError<u32> as Facet>::SHAPE;
+        assert_eq!(shape.type_identifier, "EmptyError");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,6 +221,7 @@
 //! | `arbitrary` | `std`        | No      | [`arbitrary`] | Construction of arbitrary non-empty collections.               |
 //! | `arrayvec`  |              | No      | [`arrayvec`]  | Non-empty implementations of [`arrayvec`] types.               |
 //! | `either`    |              | No      | [`either`]    | Non-empty iterator implementation for `Either`.                |
+//! | `facet`     | `alloc`      | No      | [`facet`]     | Compile-time reflection for non-empty types.                   |
 //! | `heapless`  |              | No      | [`heapless`]  | Non-empty implementations of [`heapless`] types.               |
 //! | `indexmap`  | `alloc`      | No      | [`indexmap`]  | Non-empty implementations of [`indexmap`] types.               |
 //! | `itertools` | `either`     | No      | [`itertools`] | Combinators from [`itertools`] for `Iterator1`.                |
@@ -241,6 +242,7 @@
 //! [`CowSlice1Ext`]: crate::borrow1::CowSlice1Ext
 //! [`CowStr1Ext`]: crate::borrow1::CowStr1Ext
 //! [`either`]: https://crates.io/crates/either
+//! [`facet`]: https://crates.io/crates/facet
 //! [`Except`]: crate::except
 //! [`heapless`]: https://crates.io/crates/heapless
 //! [`indexmap`]: https://crates.io/crates/indexmap
@@ -320,6 +322,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+mod facet;
 mod safety;
 mod schemars;
 mod serde;
@@ -533,6 +536,7 @@ where
 
 /// An error in which a non-empty value is expected but an empty value is observed.
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "facet", derive(::facet::Facet))]
 pub struct EmptyError<T> {
     items: T,
 }


### PR DESCRIPTION
## Summary

- Add `facet` (compile-time reflection) behind an optional `facet` feature flag
- Manual `Facet` impl for `NonEmpty<T>` marking it as a transparent wrapper with `inner` pointing to `T`'s shape
- Derive `Facet` for `EmptyError`
- Feature forwarding for `alloc`, `std`, `indexmap`

Split from #33 as requested.

## Test plan

- [x] `cargo check --features facet`
- [x] `cargo check --features facet,std`
- [x] `cargo test --features facet,std` (`NonEmpty<Vec<u8>>` shape, `EmptyError` shape)