### PR TITLE
Implement `rkyv` support for `NonEmpty`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rustdoc-args = [
 default = ["std"]
 alloc = [
     "itertools?/use_alloc",
+    "rkyv?/alloc",
     "serde?/alloc",
 ]
 arbitrary = [
@@ -42,6 +43,7 @@ arbitrary = [
 ]
 arrayvec = [
     "dep:arrayvec",
+    "rkyv?/arrayvec-0_7",
     "schemars?/arrayvec07",
 ]
 either = ["dep:either"]
@@ -49,6 +51,7 @@ heapless = ["dep:heapless"]
 indexmap = [
     "dep:indexmap",
     "alloc",
+    "rkyv?/indexmap-2",
     "schemars?/indexmap2",
 ]
 itertools = [
@@ -60,6 +63,7 @@ rayon = [
     "indexmap?/rayon",
     "std",
 ]
+rkyv = ["dep:rkyv"]
 schemars = [
     "dep:schemars",
     "dep:serde_json",
@@ -75,6 +79,7 @@ serde = [
 smallvec = [
     "dep:smallvec",
     "alloc",
+    "rkyv?/smallvec-1",
     "schemars?/smallvec1",
 ]
 std = [
@@ -82,6 +87,7 @@ std = [
     "either?/std",
     "indexmap?/std",
     "itertools?/use_std",
+    "rkyv?/std",
     "schemars?/std",
     "serde?/std",
     "smallvec?/write",
@@ -121,6 +127,11 @@ optional = true
 
 [dependencies.rayon]
 version = "^1.11.0"
+default-features = false
+optional = true
+
+[dependencies.rkyv]
+version = "^0.8.0"
 default-features = false
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ assert_eq!(xs.as_slice(), &[0]);
 
 Non-empty collection APIs that exhibit different behavior from their
 counterparts are distinct in Mitsein. For example, functions that take items out
-of collections like `Vec1::pop_if_many` have an `_if_many` suffix and  return a
+of collections like `Vec1::pop_if_many` have an `_if_many` suffix and return a
 proxy type rather than an `Option`. This leads to more explicit and distinct
 expressions like `xs.pop_if_many()`, `xs.pop_if_many().or_get_only()`, and
 `xs.remove_if_many(1).or_else_replace_only(|| 0)`.
@@ -218,7 +218,7 @@ invariants instead.
 
 Checking is toggled in the `safety` module. The presence of items in non-empty
 types is asserted in tests builds, but not in non-test builds (nor in the
-context of [Miri][`miri`]). APIs that interact with these  conditional checks
+context of [Miri][`miri`]). APIs that interact with these conditional checks
 use the nomenclature "maybe unchecked", such as `unwrap_maybe_unchecked`.
 
 ## Integrations and Feature Flags
@@ -236,6 +236,7 @@ feature flags.
 | `indexmap`  | `alloc`      | No      | [`indexmap`]  | Non-empty implementations of [`indexmap`] types.               |
 | `itertools` | `either`     | No      | [`itertools`] | Combinators from [`itertools`] for `Iterator1`.                |
 | `rayon`     | `std`        | No      | [`rayon`]     | Parallel operations for non-empty types.                       |
+| `rkyv`      |              | No      | [`rkyv`]      | Zero-copy de/serialization for non-empty types.                |
 | `schemars`  | `alloc`      | No      | [`schemars`]  | JSON schema generation for non-empty types.                    |
 | `serde`     |              | No      | [`serde`]     | De/serialization of non-empty collections with [`serde`].      |
 | `smallvec`  | `alloc`      | No      | [`smallvec`]  | Non-empty implementations of [`smallvec`] types.               |
@@ -251,6 +252,7 @@ feature flags.
 [`nonempty`]: https://crates.io/crates/nonempty
 [`nunny`]: https://crates.io/crates/nunny
 [`rayon`]: https://crates.io/crates/rayon
+[`rkyv`]: https://crates.io/crates/rkyv
 [`schemars`]: https://crates.io/crates/schemars
 [`serde`]: https://crates.io/crates/serde
 [`smallvec`]: https://crates.io/crates/smallvec

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,7 @@
 //! | `indexmap`  | `alloc`      | No      | [`indexmap`]  | Non-empty implementations of [`indexmap`] types.               |
 //! | `itertools` | `either`     | No      | [`itertools`] | Combinators from [`itertools`] for `Iterator1`.                |
 //! | `rayon`     | `std`        | No      | [`rayon`]     | Parallel operations for non-empty types.                       |
+//! | `rkyv`      |              | No      | [`rkyv`]      | Zero-copy de/serialization for non-empty types.                |
 //! | `schemars`  | `alloc`      | No      | [`schemars`]  | JSON schema generation for non-empty types.                    |
 //! | `serde`     |              | No      | [`serde`]     | De/serialization of non-empty collections with [`serde`].      |
 //! | `smallvec`  | `alloc`      | No      | [`smallvec`]  | Non-empty implementations of [`smallvec`] types.               |
@@ -249,6 +250,7 @@
 //! [`itertools`]: https://crates.io/crates/itertools
 //! [`ParallelIterator1`]: crate::iter1::ParallelIterator1
 //! [`rayon`]: https://crates.io/crates/rayon
+//! [`rkyv`]: https://crates.io/crates/rkyv
 //! [`RcSlice1Ext`]: crate::rc1::RcSlice1Ext
 //! [`RcStr1Ext`]: crate::rc1::RcStr1Ext
 //! [`schemars`]: https://crates.io/crates/schemars
@@ -320,6 +322,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+mod rkyv;
 mod safety;
 mod schemars;
 mod serde;
@@ -533,6 +536,7 @@ where
 
 /// An error in which a non-empty value is expected but an empty value is observed.
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "rkyv", derive(::rkyv::Archive, ::rkyv::Serialize, ::rkyv::Deserialize))]
 pub struct EmptyError<T> {
     items: T,
 }
@@ -763,6 +767,7 @@ where
 /// [`BTreeMap1`]: crate::btree_map1::BTreeMap1
 /// [`OccupiedEntry`]: crate::btree_map1::OccupiedEntry
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "rkyv", derive(::rkyv::Archive, ::rkyv::Serialize, ::rkyv::Deserialize))]
 pub enum Cardinality<O, M> {
     /// Exactly one item.
     One(O),

--- a/src/rkyv.rs
+++ b/src/rkyv.rs
@@ -1,0 +1,77 @@
+#![cfg(feature = "rkyv")]
+#![cfg_attr(docsrs, doc(cfg(feature = "rkyv")))]
+
+use rkyv::rancor::Fallible;
+use rkyv::{Archive, Deserialize, Place, Portable, Serialize};
+
+use crate::NonEmpty;
+
+// SAFETY: `NonEmpty<T>` is `#[repr(transparent)]` over `T`, so it has identical layout.
+// `Portable` when `T` is `Portable`.
+unsafe impl<T: Portable> Portable for NonEmpty<T> {}
+
+impl<T: Archive> Archive for NonEmpty<T> {
+    type Archived = NonEmpty<T::Archived>;
+    type Resolver = T::Resolver;
+
+    fn resolve(&self, resolver: Self::Resolver, out: Place<Self::Archived>) {
+        // SAFETY: `NonEmpty<T::Archived>` is `#[repr(transparent)]` over `T::Archived`, so the
+        // place can be safely cast.
+        let out_inner = unsafe { out.cast_unchecked::<T::Archived>() };
+        self.items.resolve(resolver, out_inner);
+    }
+}
+
+impl<T, S> Serialize<S> for NonEmpty<T>
+where
+    T: Serialize<S>,
+    S: Fallible + ?Sized,
+{
+    fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        self.items.serialize(serializer)
+    }
+}
+
+impl<T, D> Deserialize<NonEmpty<T>, D> for NonEmpty<T::Archived>
+where
+    T: Archive,
+    T::Archived: Deserialize<T, D>,
+    D: Fallible + ?Sized,
+{
+    fn deserialize(&self, deserializer: &mut D) -> Result<NonEmpty<T>, D::Error> {
+        self.items
+            .deserialize(deserializer)
+            .map(|items| NonEmpty { items })
+    }
+}
+
+#[cfg(all(test, feature = "alloc"))]
+mod tests {
+    use rkyv::rancor;
+
+    use crate::vec1::Vec1;
+
+    #[test]
+    fn roundtrip_vec1() {
+        let original = Vec1::from_head_and_tail(1u8, [2, 3, 4]);
+        let bytes = rkyv::to_bytes::<rancor::Error>(&original).unwrap();
+        let archived = unsafe { rkyv::access_unchecked::<rkyv::Archived<Vec1<u8>>>(&bytes) };
+        assert_eq!(archived.items.len(), 4);
+        assert_eq!(archived.items[0], 1);
+        assert_eq!(archived.items[3], 4);
+    }
+
+    #[test]
+    fn roundtrip_cardinality() {
+        use crate::{ArchivedCardinality, Cardinality};
+
+        let original = Cardinality::<u32, u32>::Many(42);
+        let bytes = rkyv::to_bytes::<rancor::Error>(&original).unwrap();
+        let archived =
+            unsafe { rkyv::access_unchecked::<rkyv::Archived<Cardinality<u32, u32>>>(&bytes) };
+        match archived {
+            ArchivedCardinality::Many(v) => assert_eq!(*v, 42),
+            _ => panic!("expected Many variant"),
+        }
+    }
+}

--- a/src/slice1.rs
+++ b/src/slice1.rs
@@ -150,16 +150,6 @@ impl<T> Slice1<T> {
         unsafe { safety::unwrap_option_maybe_unchecked(self.items.split_first_mut()) }
     }
 
-    pub const fn split_last(&self) -> (&T, &[T]) {
-        // SAFETY: `self` is non-empty.
-        unsafe { safety::unwrap_option_maybe_unchecked(self.items.split_last()) }
-    }
-
-    pub const fn split_last_mut(&mut self) -> (&mut T, &mut [T]) {
-        // SAFETY: `self` is non-empty.
-        unsafe { safety::unwrap_option_maybe_unchecked(self.items.split_last_mut()) }
-    }
-
     pub const fn first(&self) -> &T {
         // SAFETY: `self` is non-empty.
         unsafe { safety::unwrap_option_maybe_unchecked(self.items.first()) }


### PR DESCRIPTION
## Summary

- Add `rkyv` (zero-copy serialization) behind an optional `rkyv` feature flag
- Manual `Archive`, `Serialize`, `Deserialize`, and `Portable` impls for `NonEmpty<T>` using the `#[repr(transparent)]` layout via `Place::cast_unchecked`
- Derive macros for `EmptyError` and `Cardinality`
- Feature forwarding for `alloc`, `std`, `arrayvec`, `indexmap`, `smallvec`

Split from #33 as requested.

## Test plan

- [x] `cargo check --features rkyv`
- [x] `cargo check --features rkyv,std`
- [x] `cargo test --features rkyv,std` (roundtrip `Vec1`, `Cardinality`)