### PR TITLE
Implement `len` for `Range{,Inclusive}1<usize>`

### DIFF
--- a/src/ops1.rs
+++ b/src/ops1.rs
@@ -57,6 +57,11 @@ impl Range1<usize> {
         // SAFETY: `end` is non-zero, so the half-open range is non-empty.
         unsafe { Range1::from_range_unchecked(0..end.into()) }
     }
+
+    pub fn len(&self) -> NonZeroUsize {
+        // SAFETY: `self` is non-empty, so the length is non-zero.
+        unsafe { NonZeroUsize::new_unchecked(self.end() - self.start()) }
+    }
 }
 
 impl<T> From<Range1<T>> for Range<T> {
@@ -170,6 +175,11 @@ impl RangeInclusive1<usize> {
         // SAFETY: The closed range starts at zero and can only end at an inclusive minimum of
         //         zero, and so is non-empty.
         unsafe { RangeInclusive1::from_range_inclusive_unchecked(0..=end) }
+    }
+
+    pub fn len(&self) -> NonZeroUsize {
+        // SAFETY: (...) + 1 is non-zero.
+        unsafe { NonZeroUsize::new_unchecked((self.end() - self.start()).strict_add(1)) }
     }
 }
 

--- a/src/range1.rs
+++ b/src/range1.rs
@@ -151,6 +151,11 @@ impl Range1<usize> {
             })
         }
     }
+
+    pub fn len(&self) -> NonZeroUsize {
+        // SAFETY: `self` is non-empty, so the length is non-zero.
+        unsafe { NonZeroUsize::new_unchecked(self.end() - self.start()) }
+    }
 }
 
 impl<T> From<Range1<T>> for Range<T> {
@@ -354,6 +359,11 @@ impl RangeInclusive1<usize> {
                 last: usize::MAX,
             })
         }
+    }
+
+    pub fn len(&self) -> NonZeroUsize {
+        // SAFETY: (...) + 1 is non-zero.
+        unsafe { NonZeroUsize::new_unchecked((self.last() - self.start()).strict_add(1)) }
     }
 }
 


### PR DESCRIPTION
Should this also be added for other integer types, panicking if the result doesn't fit, to be consistent with `std::ops::range`? Note that the added implementation for `RangeInclusive1<usize>` panics for `0..=usize::MAX`.